### PR TITLE
Fixes for Olimex MOD-WIFI-ESP8266-DEV

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Before connecting the module to a microcontroller, it's important to try it dire
 ### Software and testing:
 1. Clone this repository.
 2. Unzip and execute the following command:
-```python esp8266test.py <serial_port> <ssid> <password> ```
+```python esp8266test.py <serial_port> <baud_rate> <ssid> <password> ```
 3. You should see a bunch of commands going through, including a list of available APs. Eventually, you should see the IP address assigned to the module printed.
 4. ping the IP address obtained in (3). If that works, then you got it working and can start doing cool stuff!
 

--- a/esp8266test.py
+++ b/esp8266test.py
@@ -41,14 +41,15 @@ def send_cmd( sCmd, waitTm=1, retry=5 ):
 	logging.info( "Command result: %s" % ret )
 	return ret
 
-if len(sys.argv) != 4:
-	print "Usage: esp8266test.py port ssid password"
+if len(sys.argv) != 5:
+	print "Usage: esp8266test.py port baud_rate ssid password"
 	sys.exit()
 
 port = sys.argv[1]
-speed = 9600
-ssid = sys.argv[2]
-pwd = sys.argv[3]
+#Baud rate should be: 9600 or 115200
+speed = sys.argv[2]
+ssid = sys.argv[3]
+pwd = sys.argv[4]
 
 ser = serial.Serial(port,speed)
 if ser.isOpen():
@@ -60,10 +61,11 @@ send_cmd( "AT" )
 # send_cmd( "AT+RST", 5 ) # NOTE: seems to cause problems that require manually reset (pulling down the RST pin)
 # sleep(3)
 send_cmd( "AT+CWMODE=1" ) # set device mode (1=client, 2=AP, 3=both)
+#The mode will be changed on Olimex MOD-WIFI-ESP8266-DEV only after a reset
+#The command below will reset the device
+send_cmd( "AT+RST");
 send_cmd( "AT+CWLAP", 10) # scan for WiFi hotspots
 send_cmd( "AT+CWJAP=\""+ssid+"\",\""+pwd+"\"", 5 ) # connect
 addr = send_cmd( "AT+CIFSR", 5) # check IP address
 
 ser.close()
-
-


### PR DESCRIPTION
Hi, I made a couple of changes to support Olimex MOD-WIFI-ESP8266-DEV:
1. An argument for the baud rate is passed to esp8266test.py. For MOD-WIFI-ESP8266-DEV its value should be 115200.
2. Command AT+RST must be executed after change of mode. Otherwise the update of the mode will not be applied.
