### PR TITLE
Add baud_rate option to esp8266server.py

### DIFF
--- a/esp8266server.py
+++ b/esp8266server.py
@@ -79,14 +79,15 @@ def process_request(response):
 		# process response
 		send_response(response, cid)
 
-if len(sys.argv) != 4:
-	print "Usage: esp8266test.py port ssid password"
+if len(sys.argv) != 5:
+	print "Usage: esp8266test.py port baud_rate ssid password"
 	sys.exit()
 
 port = sys.argv[1]
-speed = 9600
-ssid = sys.argv[2]
-pwd = sys.argv[3]
+#Baud rate should be: 9600 or 115200
+speed = sys.argv[2]
+ssid = sys.argv[3]
+pwd = sys.argv[4]
 p = 80
 
 ser = serial.Serial(port,speed)


### PR DESCRIPTION
When running esp8266server.py I was unable to provoke a response using an ESP-01. I realized the baud_rate was hard set to 9600 unlike the esp8266test.py which accepts an argument. I fixed this by replicating the argument sequence in esp8266test.py
